### PR TITLE
Add basic Telegram bot skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
-# tgbot
-bot for QGA
+# Telegram Bot
+
+This project contains a simple Telegram bot built with [aiogram](https://docs.aiogram.dev). The bot stores text, photo and video messages in a SQLite database. An admin web interface built with Flask allows viewing the stored data in a browser.
+
+## Requirements
+Install the dependencies using pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Configuration
+The bot uses environment variables for configuration:
+
+- `BOT_TOKEN` – Telegram bot token.
+- `DB_PATH` – path to the SQLite database file (default: `bot.db`).
+- `ADMIN_PASSWORD` – password for the admin interface (default: `admin`).
+
+## Usage
+Run the Telegram bot:
+
+```bash
+python -m bot.bot
+```
+
+Run the admin panel:
+
+```bash
+python -m bot.admin
+```
+
+Then open `http://localhost:5000` in your browser and enter the admin password to view stored messages.

--- a/bot/admin.py
+++ b/bot/admin.py
@@ -1,0 +1,42 @@
+from flask import Flask, render_template_string, request, redirect, url_for
+from .database import SessionLocal, init_db
+from .models import Message
+from .config import settings
+
+app = Flask(__name__)
+init_db()
+
+LOGIN_FORM = """
+<form method='post'>
+  <input type='password' name='password' placeholder='Password'/>
+  <input type='submit' value='Login'/>
+</form>
+"""
+
+
+@app.route('/', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        if request.form.get('password') == settings.admin_password:
+            return redirect(url_for('messages'))
+    return render_template_string(LOGIN_FORM)
+
+
+@app.route('/messages')
+def messages():
+    session = SessionLocal()
+    msgs = session.query(Message).order_by(Message.timestamp.desc()).all()
+    session.close()
+    html = "<h1>Messages</h1><ul>"
+    for m in msgs:
+        html += f"<li>({m.timestamp}) {m.user_id} [{m.message_type}] - {m.content}</li>"
+    html += "</ul>"
+    return html
+
+
+def main():
+    app.run(debug=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,0 +1,51 @@
+import logging
+from aiogram import Bot, Dispatcher, types
+from aiogram.utils import executor
+from .config import settings
+from .database import SessionLocal, init_db
+from .models import Message
+
+logging.basicConfig(level=logging.INFO)
+
+bot = Bot(token=settings.token)
+dp = Dispatcher(bot)
+
+init_db()
+
+
+@dp.message_handler(content_types=types.ContentTypes.TEXT)
+async def handle_text(message: types.Message):
+    await save_message(message.from_user.id, 'text', message.text)
+    await message.reply("Ваше сообщение сохранено")
+
+
+@dp.message_handler(content_types=types.ContentTypes.PHOTO)
+async def handle_photo(message: types.Message):
+    file_id = message.photo[-1].file_id
+    await save_message(message.from_user.id, 'photo', file_id)
+    await message.reply("Ваше фото сохранено")
+
+
+@dp.message_handler(content_types=types.ContentTypes.VIDEO)
+async def handle_video(message: types.Message):
+    file_id = message.video.file_id
+    await save_message(message.from_user.id, 'video', file_id)
+    await message.reply("Ваше видео сохранено")
+
+
+async def save_message(user_id: int, msg_type: str, content: str):
+    session = SessionLocal()
+    try:
+        msg = Message(user_id=user_id, message_type=msg_type, content=content)
+        session.add(msg)
+        session.commit()
+    finally:
+        session.close()
+
+
+def main():
+    executor.start_polling(dp, skip_updates=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,0 +1,10 @@
+import os
+from dataclasses import dataclass
+
+@dataclass
+class Settings:
+    token: str = os.getenv("BOT_TOKEN", "")
+    db_path: str = os.getenv("DB_PATH", "bot.db")
+    admin_password: str = os.getenv("ADMIN_PASSWORD", "admin")
+
+settings = Settings()

--- a/bot/database.py
+++ b/bot/database.py
@@ -1,0 +1,11 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+from .config import settings
+
+engine = create_engine(f"sqlite:///{settings.db_path}", echo=False, future=True)
+SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+Base = declarative_base()
+
+
+def init_db():
+    Base.metadata.create_all(engine)

--- a/bot/models.py
+++ b/bot/models.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, String, DateTime
+from datetime import datetime
+from .database import Base
+
+class Message(Base):
+    __tablename__ = 'messages'
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, nullable=False)
+    message_type = Column(String, nullable=False)
+    content = Column(String, nullable=False)
+    timestamp = Column(DateTime, default=datetime.utcnow)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+aiogram
+flask
+sqlalchemy


### PR DESCRIPTION
## Summary
- initialize bot package
- add aiogram-based bot for text/photo/video collection
- add simple Flask admin panel to view messages
- set up SQLAlchemy models and DB initialization
- document setup in README
- specify Python dependencies

## Testing
- `python3 -m bot.bot` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_684d0c37eeac8321881397776a9bb98b